### PR TITLE
Fix infinite loop while reading file.

### DIFF
--- a/support/gstring.c
+++ b/support/gstring.c
@@ -210,7 +210,7 @@ int gstrswp(char **first, char **second){
 int gstrline(char **line, size_t *length, FILE *file){
 	
 	int filled = 0;
-	char next = 0;
+	int next = 0;
 	char *temp = NULL;
 	
 	if (line == NULL)
@@ -223,8 +223,8 @@ int gstrline(char **line, size_t *length, FILE *file){
 		memset(*line, 0, *length);
 
 	while (1){
-		next = (char) getc(file);
-		if (next == EOF){
+		next = getc(file);
+		if (next == -1 || (char) next == EOF){
 			if (filled == 0)
 				return -1;
 			else
@@ -237,9 +237,9 @@ int gstrline(char **line, size_t *length, FILE *file){
 			*line = gstralloc(*length);
 			strcpy(*line, temp);
 		};
-		(*line)[filled] = next;
+		(*line)[filled] = (char) next;
 		filled++;
-		if (next == '\n')
+		if ((char) next == '\n')
 			return filled;
 	};
 	


### PR DESCRIPTION
Issue encountered on a machine with armv7l architecture under GNU/Linux.
The getc() function return -1 for EOF. Storing the return value in a char may never succeed because sign-extension of a variable of type char on widening to integer is implementation-defined.
It was the case on the tested platform causing a never ending while loop because the comparison with EOF was never true.
By using an integer comparison directly, we make sure that we stop the loop when getc() returns -1.